### PR TITLE
Implementation of Logger and Disabling sending logs to server.

### DIFF
--- a/src/main/java/bark/client/constants/Global.java
+++ b/src/main/java/bark/client/constants/Global.java
@@ -14,5 +14,6 @@ public class Global {
     public static final String Debug = "DEBUG";
     public static final String DefaultLogCode = "000000";
     public static final String DefaultLogLevel = "INFO";
+    public static final String DisabledServerUrl = "http://0.0.0.0/";
 
 }

--- a/src/main/java/bark/client/examples/Client_ClientLoggerOnly.java
+++ b/src/main/java/bark/client/examples/Client_ClientLoggerOnly.java
@@ -1,0 +1,27 @@
+package bark.client.examples;
+
+import bark.client.constants.Global;
+import bark.client.models.Config;
+import bark.client.util.CustomLogFormatter;
+
+import java.io.IOException;
+import java.util.logging.FileHandler;
+
+import static bark.client.models.Config.NewLoggerBarkClient;
+
+public class Client_ClientLoggerOnly {
+    public static void main(String[] args) throws IOException {
+        Config logConf = NewLoggerBarkClient(Global.Info);
+        FileHandler fileHandler = new FileHandler("output_logger.log", true);
+        fileHandler.setFormatter(new CustomLogFormatter());
+        logConf.setLoggerHandler(fileHandler);
+
+        logConf.Info("Hello Info Logger Only");
+        logConf.Debug("Hello Debug Logger Only");
+        logConf.Panic("Hello Panic Logger Only");
+        logConf.Alert("Hello Alert Logger Only");
+        logConf.Warn("Hello Warn Logger Only");
+        logConf.Error("Hello Error Logger Only");
+        logConf.Notice("Hello Notice Logger Only");
+    }
+}

--- a/src/main/java/bark/client/examples/Client_Simple.java
+++ b/src/main/java/bark/client/examples/Client_Simple.java
@@ -5,18 +5,27 @@ import bark.client.constants.Global;
 import bark.client.models.Config;
 import bark.client.models.MoreData;
 import bark.client.models.RawLog;
+import bark.client.util.CustomLogFormatter;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.logging.FileHandler;
 
 import static bark.client.models.Config.BarkClient;
+import static bark.client.models.Config.NewLoggerBarkClient;
 
 public class Client_Simple {
 
     public static void main(String[] args) throws IOException {
-        Config logConf = BarkClient("http://localhost:8080/", Global.Info, "testSvc", "testSess");
+        Config logConf = BarkClient("http://localhost:8080/", Global.Info, "testSvc", "testSess", true);
+        FileHandler fileHandler = new FileHandler("output_logger.log");
+        fileHandler.setFormatter(new CustomLogFormatter());
+        logConf.clearHandlers(); // If this method is not called, it'll only append FileHandler to logger along with default ConsoleHandler i.e. Output will be on both file and console.
+        logConf.setLoggerHandler(fileHandler);
         simpleTest(logConf);
         rawLogMoreDataTest(logConf);
+
+        disableLogger();
     }
 
     public static void simpleTest(Config logConf) throws IOException {
@@ -64,5 +73,17 @@ public class Client_Simple {
         rawLog.setMoreData(moreData);
 
         logConf.Raw(rawLog);
+    }
+
+    public static void disableLogger() throws IOException {
+        Config logConf = BarkClient("http://localhost:8080/", Global.Info, "testSvc", "testSess", false);
+
+        logConf.Info("Hello Server. Not you Logger!");
+        logConf.Debug("Hello Server. Not you Logger!");
+        logConf.Panic("Hello Server. Not you Logger!");
+        logConf.Alert("Hello Server. Not you Logger!");
+        logConf.Warn("Hello Server. Not you Logger!");
+        logConf.Error("Hello Server. Not you Logger!");
+        logConf.Notice("Hello Server. Not you Logger!");
     }
 }

--- a/src/main/java/bark/client/models/BarkLog.java
+++ b/src/main/java/bark/client/models/BarkLog.java
@@ -35,5 +35,27 @@ public class BarkLog {
         this.moreData = moreData;
     }
 
+    public Date getLogTime() {
+        return logTime;
+    }
 
+    public String getLogLevel() {
+        return logLevel;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public String getSessionName() {
+        return sessionName;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
 }

--- a/src/main/java/bark/client/models/Config.java
+++ b/src/main/java/bark/client/models/Config.java
@@ -4,73 +4,156 @@ import bark.client.constants.Global;
 import bark.client.requestchannel.ClientChannel;
 import bark.client.services.ingestion.LogIngester;
 import bark.client.services.sender.LogSender;
+import bark.client.util.BarkLogger;
+import bark.client.util.CustomLogFormatter;
 
 import java.io.IOException;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
+
+import static bark.client.util.BarkLogger.*;
 
 public class Config {
     private String baseUrl;
     private String errorLevel;
     private  String serviceName;
     private String sessionName;
+    private Logger logger;
 
     public void Panic(String message) throws IOException {
-        System.out.println(message);
         BarkLog log = new BarkLog(Global.Panic, this.serviceName, this.sessionName, Global.DefaultLogCode,message);
         dispatchLogMessage(log);
+        if(logger != null){
+            logger.log(LvlPanic, message);
+        }
     }
     public void Alert(String message) throws IOException {
-        System.out.println(message);
         BarkLog log = new BarkLog(Global.Alert, this.serviceName, this.sessionName, Global.DefaultLogCode,message);
         dispatchLogMessage(log);
+        if(logger != null){
+            logger.log(LvlAlert, message);
+        }
     }
     public void Error(String message) throws IOException {
-        System.out.println(message);
         BarkLog log = new BarkLog(Global.Error, this.serviceName, this.sessionName, Global.DefaultLogCode,message);
         dispatchLogMessage(log);
+        if(logger != null){
+            logger.log(LvlError, message);
+        }
     }
     public void Warn(String message) throws IOException {
-        System.out.println(message);
         BarkLog log = new BarkLog(Global.Warning, this.serviceName, this.sessionName, Global.DefaultLogCode,message);
         dispatchLogMessage(log);
+        if(logger != null){
+            logger.log(LvlWarn, message);
+        }
     }
     public void Notice(String message) throws IOException {
-        System.out.println(message);
         BarkLog log = new BarkLog(Global.Notice, this.serviceName, this.sessionName, Global.DefaultLogCode,message);
         dispatchLogMessage(log);
+        if(logger != null){
+            logger.log(LvlNotice, message);
+        }
     }
     public void Info(String message) throws IOException {
-        System.out.println(message);
         BarkLog log = new BarkLog(Global.Info, this.serviceName, this.sessionName, Global.DefaultLogCode,message);
         dispatchLogMessage(log);
+        if(logger != null){
+            logger.log(LvlInfo, message);
+        }
     }
     public void Debug(String message) throws IOException {
-        System.out.println(message);
         BarkLog log = new BarkLog(Global.Debug, this.serviceName, this.sessionName, Global.DefaultLogCode,message);
         dispatchLogMessage(log);
+        if(logger != null){
+            logger.log(LvlDebug, message);
+        }
     }
 
     public void Raw(RawLog rawLog) throws IOException {
         BarkLog log = new BarkLog(rawLog.getLogLevel(),rawLog.getServiceName(), rawLog.getSessionName(), rawLog.getCode(), rawLog.getMessage());
         log.setMoreData(rawLog.getMoreData());
         dispatchLogMessage(log);
+
+        switch (log.getLogLevel()) {
+            case Global.Panic:
+                logger.log(LvlPanic, log.getMessage());
+                break;
+            case Global.Notice:
+                logger.log(LvlNotice, log.getMessage());
+                break;
+            case Global.Alert:
+                logger.log(LvlAlert, log.getMessage());
+                break;
+            case Global.Error:
+                logger.log(LvlError, log.getMessage());
+                break;
+            case Global.Warning:
+                logger.log(LvlWarn, log.getMessage());
+                break;
+            case Global.Debug:
+                logger.log(LvlDebug, log.getMessage());
+                break;
+            case Global.Info:
+            default:
+                logger.log(LvlInfo, log.getMessage());
+                break;
+        }
     }
 
     public Config() {}
-    private Config(String baseUrl, String errorLevel, String serviceName, String sessionName) {
+    private Config(String baseUrl, String errorLevel, String serviceName, String sessionName, Logger logger) {
         this.baseUrl = baseUrl;
         this.errorLevel = errorLevel;
         this.serviceName = serviceName;
         this.sessionName = sessionName;
+        this.logger = logger;
     }
-    public static Config BarkClient(String baseUrl, String errorLevel, String serviceName, String sessionName) {
+
+    public static Config NewLoggerBarkClient(String defaultLogLevel) {
+        if(!BarkLogger.isValidLogLevel(defaultLogLevel)){
+            System.out.println(String.format("L#1MFJJC - %s is not an acceptable log level. %s will be used as the default log level", defaultLogLevel, Global.DefaultLogLevel));
+            defaultLogLevel = Global.DefaultLogLevel;
+        }
+        ConsoleHandler consoleHandler = new ConsoleHandler();
+        consoleHandler.setFormatter(new CustomLogFormatter());
+        Logger logger = newLogger("OfflineBarkLogger",consoleHandler);
+        return new Config(Global.DisabledServerUrl, defaultLogLevel, "","", logger);
+    }
+    public static Config BarkClient(String baseUrl, String errorLevel, String serviceName, String sessionName, boolean enableLogger) {
         ClientChannel.createChannel();
         LogSender logSender = new LogSender();
         logSender.startSendingLogs(baseUrl);
-        return new Config(baseUrl,errorLevel,serviceName,sessionName);
+        Logger logger;
+        if(enableLogger){
+            ConsoleHandler consoleHandler = new ConsoleHandler();
+            consoleHandler.setFormatter(new CustomLogFormatter());
+            logger = newLogger("BarkLogger",consoleHandler);
+        } else {
+            logger = null;
+        }
+        return new Config(baseUrl,errorLevel,serviceName,sessionName, logger);
 
     }
 
     private void dispatchLogMessage(BarkLog barkLog) throws IOException {
         LogIngester.SendToClientChannel(barkLog);
+    }
+
+
+    public void clearHandlers(){
+        if(logger == null){
+            return;
+        }
+
+        Handler[] handlers = logger.getHandlers();
+
+        for(Handler handler1: handlers){
+            logger.removeHandler(handler1);
+        }
+    }
+    public void setLoggerHandler(Handler handler){
+        logger.addHandler(handler);
     }
 }

--- a/src/main/java/bark/client/services/ingestion/LogIngester.java
+++ b/src/main/java/bark/client/services/ingestion/LogIngester.java
@@ -8,6 +8,10 @@ import java.util.concurrent.Executors;
 
 public class LogIngester {
     public static void SendToClientChannel(BarkLog barkLog) {
+        if(ClientChannel.ClientQueue == null){
+            System.out.println("E#1MFJIZ - Queue not initialized, Are you running Logger mode only?");
+            return;
+        }
         if(ClientChannel.ClientQueue.size()  < ClientChannel.ClientChannelCapacity - 1) {
             ClientChannel.ClientQueue.add(barkLog);
         }

--- a/src/main/java/bark/client/util/BarkLogger.java
+++ b/src/main/java/bark/client/util/BarkLogger.java
@@ -1,0 +1,40 @@
+package bark.client.util;
+
+import bark.client.constants.Global;
+
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class BarkLogger {
+    public static final Level LvlPanic = new Level(Global.Panic, Level.INFO.intValue()+500){};
+    public static final Level LvlAlert = new Level(Global.Alert, Level.INFO.intValue()+400){};
+    public static final Level LvlError = new Level(Global.Error, Level.INFO.intValue()+300){};
+    public static final Level LvlWarn = new Level(Global.Warning, Level.INFO.intValue()+200){};
+    public static final Level LvlNotice = new Level(Global.Notice, Level.INFO.intValue()+100){};
+    public static final Level LvlInfo = Level.INFO;
+    public static final Level LvlDebug = new Level(Global.Debug, Level.INFO.intValue()-100){};
+
+    public static Logger newLogger(String loggerName, Handler handler){
+        Logger logger = Logger.getLogger(loggerName);
+        logger.addHandler(handler);
+        logger.setUseParentHandlers(false);
+        logger.setLevel(Level.ALL);
+        return logger;
+    }
+
+    public static boolean isValidLogLevel(String level){
+        switch (level) {
+            case Global.Panic:
+            case Global.Notice:
+            case Global.Alert:
+            case Global.Error:
+            case Global.Warning:
+            case Global.Info:
+            case Global.Debug:
+                return true;
+            default:
+                return false;
+        }
+    }
+}

--- a/src/main/java/bark/client/util/CustomLogFormatter.java
+++ b/src/main/java/bark/client/util/CustomLogFormatter.java
@@ -1,0 +1,20 @@
+package bark.client.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+public class CustomLogFormatter extends Formatter {
+
+    private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+    @Override
+    public String format(LogRecord record) {
+        String formattedDate = dateFormat.format(new Date(record.getMillis()));
+        String logLevel = record.getLevel().getName();
+        String logMessage = formatMessage(record);
+
+        return formattedDate + " " + logLevel + " " + logMessage + "\n";
+    }
+}


### PR DESCRIPTION
Fixes #5 , in a way, that it introduces a new method of that specific functionality only like we have NewSloggerClient in Go Client.

- Implemented Logger using java.util.logging.
- User can provide their custom Handlers with their custom formatter to this logger.
- Introduced a new function(NewLoggerBarkClient) to create LogConf that'll only send logs to Logger and not to the server.
- Added CustomLogFormatter.java, that'll enable logging in format of: LOG_TIME LOG_LEVEL LOG_MSG